### PR TITLE
Create metric logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The **Quaver SV Difficulty System** (or **_QSVDS_** for short) is a player-managed database of SV charts and their respective difficulties. The site is meant to provide information to both SV beginners and SV pros, as well as for players to show off their SV prowess. QSVDS is based solely on [Quaver](https://github.com/Quaver/Quaver) and its APIs.
 
+### Note that the current design is very incomplete. The site will undergo a complete overhaul spearheaded by zeph.
+
 # List of Contributors
 
 -   <img src="https://github.com/ESV-Sweetplum.png" width="12"> [ESV-Sweetplum](https://github.com/ESV-Sweetplum) - Developer
@@ -40,9 +42,11 @@ This website is built with the [Next.js](https://nextjs.org) framework, and host
 -   Database hosted with [Supabase](https://supabase.com).
 -   API-Database connection done with [Prisma](https://www.prisma.io).
 -   Fetching/HTTP requests done with [axios](https://axios-http.com) (most likely going to migrate to xior for middleware support).
+-   Cron hosting for metrics and live updates done with [val town](https://www.val.town).
 
 ## Styling Packages
 
+-   Designs done with [Figma](https://www.figma.com).
 -   CSS extension done with [Sass](https://sass-lang.com).
 -   Components built with [Radix Themes](https://www.radix-ui.com).
 -   Text fitting algorithm implemented with [react-textfit](https://www.npmjs.com/package/react-textfit).

--- a/prisma/migrations/20240714012729_add_metric/migration.sql
+++ b/prisma/migrations/20240714012729_add_metric/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "Metric" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userCount" INTEGER NOT NULL DEFAULT 0,
+    "mapCount" INTEGER NOT NULL DEFAULT 0,
+    "ratingCount" INTEGER NOT NULL DEFAULT 0,
+    "scoreCount" INTEGER NOT NULL DEFAULT 0,
+    "categoryMapCount" INTEGER[] DEFAULT ARRAY[0, 0, 0, 0, 0]::INTEGER[],
+
+    CONSTRAINT "Metric_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,16 @@ model Rating {
     rating Int
 }
 
+model Metric {
+    id Int @id @default(autoincrement())
+    createdAt DateTime @default(now())
+    userCount Int @default(0)
+    mapCount Int @default(0)
+    ratingCount Int @default(0)
+    scoreCount Int @default(0)
+    categoryMapCount Int[] @default([0, 0, 0, 0, 0])
+}
+
 enum Category {
     Reading
     Hybrid

--- a/src/app/api/metric/route.ts
+++ b/src/app/api/metric/route.ts
@@ -5,6 +5,8 @@ import { Category, Prisma } from "@prisma/client";
 export async function POST(request: NextRequest) {
     const authHeader = request.headers.get("authorization");
 
+    console.log(authHeader);
+
     if (authHeader !== `Bearer ${process.env.CRON_AUTH}`)
         return Response.json({ status: 401, message: "Unauthorized" });
 

--- a/src/app/api/metric/route.ts
+++ b/src/app/api/metric/route.ts
@@ -8,7 +8,12 @@ export async function POST(request: NextRequest) {
     console.log(authHeader);
 
     if (authHeader !== `Bearer ${process.env.CRON_AUTH}`)
-        return Response.json({ status: 401, message: "Unauthorized" });
+        return Response.json({
+            status: 401,
+            message: "Unauthorized",
+            authHeader,
+            auth: process.env.CRON_AUTH,
+        });
 
     const userCount = await prisma.user.count();
     const mapCount = await prisma.map.count();

--- a/src/app/api/metric/route.ts
+++ b/src/app/api/metric/route.ts
@@ -11,8 +11,6 @@ export async function POST(request: NextRequest) {
         return Response.json({
             status: 401,
             message: "Unauthorized",
-            authHeader,
-            auth: process.env.CRON_AUTH,
         });
 
     const userCount = await prisma.user.count();

--- a/src/app/api/metric/route.ts
+++ b/src/app/api/metric/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from "next/server";
+import prisma from "../../../../prisma/initialize";
+import { Category, Prisma } from "@prisma/client";
+
+export async function POST(request: NextRequest) {
+    const authHeader = request.headers.get("authorization");
+
+    if (authHeader !== `Bearer ${process.env.CRON_AUTH}`)
+        return Response.json({ status: 401, message: "Unauthorized" });
+
+    const userCount = await prisma.user.count();
+    const mapCount = await prisma.map.count();
+    const ratingCount = await prisma.rating.count();
+
+    const categories: Category[] = [
+        "Reading",
+        "Hybrid",
+        "Memory",
+        "Reverse",
+        "Splitscroll",
+    ];
+
+    const categoryMapCount = [];
+
+    for (let i = 0; i < categories.length; i++) {
+        const count = await prisma.map.count({
+            where: { category: categories[i] },
+        });
+        categoryMapCount.push(count);
+    }
+
+    await prisma.metric.create({
+        data: {
+            userCount,
+            mapCount,
+            ratingCount,
+            scoreCount: 0,
+            categoryMapCount,
+        },
+    });
+}


### PR DESCRIPTION
At 12:00am UTC, a cron job is run such that it counts the records of the database, and creates a new entry in the `Metric` table. It is interfaced as such in the schema:

```prisma
model Metric {
    id Int @id @default(autoincrement())
    createdAt DateTime @default(now())
    userCount Int @default(0)
    mapCount Int @default(0)
    ratingCount Int @default(0)
    scoreCount Int @default(0)
    categoryMapCount Int[] @default([0, 0, 0, 0, 0])
}
```

Currently, since score logging isn't supported, `metric.scoreCount` will be 0 until later implemented. Also note that categoryMapCount's length is fragile and subject to change, if more categories are added.